### PR TITLE
Modify example fleet file's KeyName

### DIFF
--- a/files/exampleFleet_us-east-1.json
+++ b/files/exampleFleet_us-east-1.json
@@ -5,7 +5,7 @@
   "LaunchSpecifications": [
     {
       "ImageId": "ami-fad25980",
-      "KeyName": "your_key_file_name",
+      "KeyName": "your-key-file",
       "IamInstanceProfile": {
         "Arn": "arn:aws:iam::XXXXXXXXXXXX:instance-profile/ecsInstanceRole"
       },

--- a/files/exampleFleet_us-west-2.json
+++ b/files/exampleFleet_us-west-2.json
@@ -5,7 +5,7 @@
   "LaunchSpecifications": [
     {
       "ImageId": "ami-c9c87cb1",
-      "KeyName": "your_key_file_name",
+      "KeyName": "your-key-file",
       "IamInstanceProfile": {
         "Arn": "arn:aws:iam::XXXXXXXXXXXX:instance-profile/ecsInstanceRole"
       },


### PR DESCRIPTION
- modify to match value in config.py sans .pem, as stated in docs

Docs state [here](https://distributedscience.github.io/Distributed-Something/step_3_start_cluster.html#configuring-your-spot-fleet-request)

> The KeyName used here should be the same used in your config file but without the .pem extension.

I realize these are dummy values, but matching them anyway may avoid some confusion